### PR TITLE
Add chain identifier constant

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -3,6 +3,7 @@
 use std::collections::{HashMap, HashSet};
 use crate::types::{Hash, CommitmentMeta};
 
+pub const CHAIN_ID: u64 = 1;
 pub const COMMIT_FEE: u64 = 1;
 pub const REVEAL_WINDOW: u64 = 3;
 pub const DECRYPTION_DELAY: u64 = 1;   // blocks after commit before reveals may start


### PR DESCRIPTION
## Summary
- add public `CHAIN_ID` constant to `state` module for hashing and replay protection

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_689ef6da7b50832e8fddc14cf0766b8f