### PR TITLE
Include access list in commitment hash

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -217,7 +217,9 @@ fn applying_2_blocks_works_correctly() {
     // Inner tx to be revealed
     let tx = Transaction::transfer(sender.clone(), receiver.clone(), 10, 0);
     let salt: Hash = [3u8; 32];
-    let cmt = commitment_hash(&tx_bytes(&tx), &salt, CHAIN_ID);
+    let tx_ser = tx_bytes(&tx);
+    let tx_al_bytes = access_list_bytes(&tx.access_list);
+    let cmt = commitment_hash(&tx_ser, &tx_al_bytes, &salt, CHAIN_ID);
 
     let al = AccessList {
         reads:  vec![ StateKey::Balance(sender.clone().into()), StateKey::Nonce(sender.clone().into()), StateKey::Balance(receiver.clone().into()) ],
@@ -445,7 +447,9 @@ fn inclusion_list_due_must_be_included() {
     // Build inner tx + salt so we can compute the matching commitment
     let inner = Transaction::transfer(&sender, recipient.clone(), 10, 0);
     let salt: Hash = [9u8; 32];
-    let cmt  = commitment_hash(&tx_bytes(&inner), &salt, CHAIN_ID);
+    let inner_ser = tx_bytes(&inner);
+    let inner_al_bytes = access_list_bytes(&inner.access_list);
+    let cmt  = commitment_hash(&inner_ser, &inner_al_bytes, &salt, CHAIN_ID);
 
     // ---- Block 1: Commit (signed) ----
     let ciphertext_hash = [2u8; 32];
@@ -589,11 +593,15 @@ fn reveal_bundle_executes_multiple_reveals_and_satisfies_il() {
     // two inner transfers (use sequential nonces per sender)
     let t1 = Transaction::transfer(&sender, &recipient, 10, 0);
     let s1: Hash = [1u8; 32];
-    let c1 = commitment_hash(&tx_bytes(&t1), &s1, CHAIN_ID);
+    let t1_ser = tx_bytes(&t1);
+    let t1_al_bytes = access_list_bytes(&t1.access_list);
+    let c1 = commitment_hash(&t1_ser, &t1_al_bytes, &s1, CHAIN_ID);
 
     let t2 = Transaction::transfer(&sender, &recipient, 20, 1);
     let s2: Hash = [2u8; 32];
-    let c2 = commitment_hash(&tx_bytes(&t2), &s2, CHAIN_ID);
+    let t2_ser = tx_bytes(&t2);
+    let t2_al_bytes = access_list_bytes(&t2.access_list);
+    let c2 = commitment_hash(&t2_ser, &t2_al_bytes, &s2, CHAIN_ID);
 
     // block 1: commits (two) — both signed
     let ciphertext_hash = [0u8; 32];
@@ -904,7 +912,9 @@ fn inclusion_list_due_but_missing_reveal_rejects_block() {
     // Build inner tx + salt → commitment
     let inner = Transaction::transfer(&sender, &recipient, 10, 0);
     let salt: Hash = [9u8; 32];
-    let cmt  = commitment_hash(&tx_bytes(&inner), &salt, CHAIN_ID);
+    let inner_ser = tx_bytes(&inner);
+    let inner_al_bytes = access_list_bytes(&inner.access_list);
+    let cmt  = commitment_hash(&inner_ser, &inner_al_bytes, &salt, CHAIN_ID);
 
     // Block 1: commit (signed)
     let ciphertext_hash = [2u8; 32];

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -36,8 +36,11 @@ pub fn string_bytes(s: &str) -> Vec<u8> {
 // Returns canonical bytes for AccessList (sorted + length-prefixed lists)
 // Reuse the same logic as put_access_list, but write into a fresh Vec and return it.
 pub fn access_list_bytes(al: &AccessList) -> Vec<u8> {
+    // work on a canonicalized clone (sorted + dedup) to ensure stable bytes
+    let mut canon = al.clone();
+    canon.canonicalize();
     let mut v = Vec::new();
-    put_access_list(&mut v, al);
+    put_access_list(&mut v, &canon);
     v
 }
 

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -81,13 +81,21 @@ pub fn avail_signing_preimage(
     buf
 }
 
-pub fn commitment_hash(tx_bytes: &[u8], salt: &Hash, chain_id: u64) -> Hash {
-    // capacity = domain + chain_id(8) + tx + salt(32)
-    let mut buf = Vec::with_capacity(COMMIT_DOMAIN.len() + 8 + tx_bytes.len() + 32);
+pub fn commitment_hash(
+    tx_bytes: &[u8],
+    access_list_bytes: &[u8],
+    salt: &Hash,
+    chain_id: u64,
+) -> Hash {
+    // capacity = domain + chain_id(8) + tx + salt(32) + access_list_hash(32)
+    let mut buf = Vec::with_capacity(COMMIT_DOMAIN.len() + 8 + tx_bytes.len() + 32 + 32);
     buf.extend_from_slice(COMMIT_DOMAIN);
     buf.extend_from_slice(&chain_id.to_le_bytes());
     buf.extend_from_slice(tx_bytes);
     buf.extend_from_slice(salt);
+    // keep commitment size stable by hashing the access list bytes
+    let al_hash = hash_bytes_sha256(access_list_bytes);
+    buf.extend_from_slice(&al_hash);
     hash(&buf)
 }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,6 +1,6 @@
 //src/verify.rs
 
-use crate::{codec::{receipt_bytes, tx_bytes, tx_enum_bytes}, crypto::{hash_bytes_sha256, merkle_root}, state::CHAIN_ID, types::{Block, BlockHeader, Hash, Receipt}};
+use crate::{codec::{receipt_bytes, tx_bytes, tx_enum_bytes, access_list_bytes}, crypto::{hash_bytes_sha256, merkle_root}, state::CHAIN_ID, types::{Block, BlockHeader, Hash, Receipt}};
 
 pub fn compute_roots_for(block: &Block, receipts: &[Receipt]) -> (Hash, Hash, Hash) {
     // txs_root from block.transactions (reveals are NOT part of txs_root)
@@ -22,7 +22,8 @@ pub fn compute_roots_for(block: &Block, receipts: &[Receipt]) -> (Hash, Hash, Ha
         .iter()
         .map(|r| {
             let ser = tx_bytes(&r.tx);
-            let cmt = crate::crypto::commitment_hash(&ser, &r.salt, CHAIN_ID);
+            let al_bytes = access_list_bytes(&r.tx.access_list);
+            let cmt = crate::crypto::commitment_hash(&ser, &al_bytes, &r.salt, CHAIN_ID);
             let txh = hash_bytes_sha256(&ser);
             (cmt, txh)
         })


### PR DESCRIPTION
## Summary
- incorporate hashed access list into transaction commitments
- verify reveal commitments against stored access lists
- canonicalize access list bytes before hashing

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a0e9db00c8832ebb74021fc80f2d6e