### PR TITLE
Fix mempool proptest by generating matching commits and sequential nonces

### DIFF
--- a/tests/prop_selection.proptest-regressions
+++ b/tests/prop_selection.proptest-regressions
@@ -4,4 +4,4 @@
 #
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
-cc fc1eeccffca9ec27a8f015e4d7c317c33645f66041c59d33d1019d2bbc0a44cc # shrinks to il = [CommitmentId([0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])], sender = "a", include_required = true
+cc 82b06cbf5d14c5b3d56ebdb2e2c2f5e71a15178161f9bbd7ae9f81339ba3be71 # shrinks to salts = [[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0], [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1]], sender = "0x0000000000000000000000000000000000000000", include_required = true


### PR DESCRIPTION
## Summary
- build commit+reveal pairs with valid hex addresses for each salt
- increment reveal nonces per commitment so selection sees required sequence
- update regression seed for the mempool property test

## Testing
- `cargo test --test prop_selection -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_b_68a21db7d3e8832eae95d8dfbb533fee