### PR TITLE
Add Chain state queries for mempool

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -2,20 +2,36 @@
 
 use crate::fees::{update_commit_base, update_exec_base, FeeState, FEE_PARAMS};
 use crate::stf::{process_block, BlockResult, BlockError};
-use crate::state::{Available, Balances, Commitments, Nonces, CHAIN_ID, DECRYPTION_DELAY, REVEAL_WINDOW, ZERO_ADDRESS};
-use crate::types::{Block, Hash};
+use crate::state::{Available, Balances, Commitments, Nonces, DECRYPTION_DELAY, REVEAL_WINDOW, ZERO_ADDRESS};
+#[cfg(test)]
+use crate::state::CHAIN_ID;
+use crate::types::{Block, Hash, Event};
 use crate::verify::verify_block_roots;
+use std::collections::{HashMap, HashSet, BTreeMap};
 
 pub struct Chain {
     pub tip_hash: Hash,
     pub height: u64,
     pub fee_state: FeeState,
     pub burned_total: u64,
+    commit_included_at: HashMap<Hash, u64>,
+    avail_included: HashSet<Hash>,
+    avail_due: BTreeMap<u64, Vec<Hash>>,
+    commit_deadline: HashMap<Hash, u64>,
 }
 
 impl Chain {
     pub fn new() -> Self {
-        Self { tip_hash: [0u8;32], height: 0, fee_state: FeeState::from_defaults(), burned_total: 0 }
+        Self {
+            tip_hash: [0u8;32],
+            height: 0,
+            fee_state: FeeState::from_defaults(),
+            burned_total: 0,
+            commit_included_at: HashMap::new(),
+            avail_included: HashSet::new(),
+            avail_due: BTreeMap::new(),
+            commit_deadline: HashMap::new(),
+        }
     }
 
     // Returns BlockResult on success (so caller can inspect roots, receipts, etc.)
@@ -25,7 +41,7 @@ impl Chain {
         balances: &mut Balances,
         nonces: &mut Nonces,
         commitments: &mut Commitments,
-        available: &mut Available,  
+        available: &mut Available,
     ) -> Result<BlockResult, BlockError> {
         // 1) basic height check
         if block.block_number != self.height + 1 {
@@ -72,6 +88,33 @@ impl Chain {
         *commitments = sim_commitments;
         *available = sim_available;
 
+        for ev in &res.events {
+            match ev {
+                Event::CommitStored { commitment, .. } => {
+                    self.commit_included_at.insert(*commitment, block.block_number);
+                }
+                Event::AvailabilityRecorded { commitment } => {
+                    if let Some(&inc) = self.commit_included_at.get(commitment) {
+                        let ready_at = inc + DECRYPTION_DELAY;
+                        let deadline = ready_at + REVEAL_WINDOW;
+                        self.avail_included.insert(*commitment);
+                        self.commit_deadline.insert(*commitment, deadline);
+                        self.avail_due.entry(deadline).or_default().push(*commitment);
+                    }
+                }
+                Event::CommitConsumed { commitment } | Event::CommitExpired { commitment } => {
+                    if let Some(deadline) = self.commit_deadline.remove(commitment) {
+                        if let Some(vec) = self.avail_due.get_mut(&deadline) {
+                            vec.retain(|c| c != commitment);
+                            if vec.is_empty() {
+                                self.avail_due.remove(&deadline);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
         let next_exec = update_exec_base(
             self.fee_state.exec_base,
             res.exec_reveals_used,
@@ -90,6 +133,32 @@ impl Chain {
             res.commits_used,
         );
         Ok(res)
+    }
+
+    /// Check if a commitment has been included on-chain.
+    pub fn commit_on_chain(&self, c: &Hash) -> bool {
+        self.commit_included_at.contains_key(c)
+    }
+
+    /// Check if an Avail for the commitment has been included.
+    pub fn avail_on_chain(&self, c: &Hash) -> bool {
+        self.avail_included.contains(c)
+    }
+
+    /// Whether an Avail is allowed at `height` for commitment `c`.
+    pub fn avail_allowed_at(&self, height: u64, c: &Hash) -> bool {
+        if let Some(&included_at) = self.commit_included_at.get(c) {
+            let ready_at = included_at + DECRYPTION_DELAY;
+            let deadline = ready_at + REVEAL_WINDOW;
+            height >= ready_at && height <= deadline
+        } else {
+            false
+        }
+    }
+
+    /// Commitments that are due (deadline == `height`) and already available.
+    pub fn commitments_due_and_available(&self, height: u64) -> Vec<Hash> {
+        self.avail_due.get(&height).cloned().unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
## Summary
- track on-chain commitments and availability with lightweight indices
- expose Chain read APIs for commitments, availability, and due lists
- have NodeStateView call Chain for these queries instead of placeholders

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a47b917bd0832e8b1d59335bbc7416