### PR TITLE
Make Node fields private and add accessors

### DIFF
--- a/src/fees.rs
+++ b/src/fees.rs
@@ -326,14 +326,12 @@ mod tests {
         let mut node = Node::new(Arc::clone(&mempool));
 
         // Initial state
-        node.balances = HashMap::from([
-            (sender.clone(), 200u64),
-            (proposer.clone(), 0u64),
-        ]);
+        node.set_balance(sender.clone(), 200u64);
+        node.set_balance(proposer.clone(), 0u64);
 
         // Chain with higher commit fee so proposer share > 0
-        node.chain.fee_state.commit_base = 100;
-        let commit_fee = node.chain.fee_state.commit_base;
+        node.set_commit_fee_base(100);
+        let commit_fee = node.fee_state().commit_base;
         let (burn_share, proposer_share, _tres) = split_amount(commit_fee);
 
         // Access list required for commit
@@ -361,10 +359,10 @@ mod tests {
         mempool
             .insert_commit(
                 Tx::Commit(commit_tx),
-                node.chain.height,
+                node.height(),
                 commit_fee as u128,
                 &TestBalanceView,
-                &node.chain.fee_state,
+                node.fee_state(),
             )
             .expect("commit admitted");
 
@@ -376,9 +374,9 @@ mod tests {
             })
             .expect("block should apply");
 
-        assert_eq!(node.balances[&proposer], proposer_share);
-        assert_eq!(node.chain.burned_total, burn_share);
-        assert_eq!(node.balances[&sender], 200 - commit_fee);
+        assert_eq!(node.balance_of(&proposer), proposer_share);
+        assert_eq!(node.burned_total(), burn_share);
+        assert_eq!(node.balance_of(&sender), 200 - commit_fee);
     }
 
     #[test]

--- a/src/node.rs
+++ b/src/node.rs
@@ -36,12 +36,12 @@ pub enum ProduceError {
 }
 
 pub struct Node {
-    pub chain: Chain,
-    pub balances: Balances,
-    pub nonces: Nonces,
-    pub commitments: Commitments,
-    pub available: Available,
-    pub mempool: Arc<MempoolImpl>,
+    chain: Chain,
+    balances: Balances,
+    nonces: Nonces,
+    commitments: Commitments,
+    available: Available,
+    mempool: Arc<MempoolImpl>,
 }
 
 struct NodeStateView<'a> {
@@ -96,6 +96,30 @@ impl Node {
             available: Default::default(),
             mempool,
         }
+    }
+
+    pub fn height(&self) -> u64 {
+        self.chain.height
+    }
+
+    pub fn fee_state(&self) -> &crate::fees::FeeState {
+        &self.chain.fee_state
+    }
+
+    pub fn set_commit_fee_base(&mut self, base: u64) {
+        self.chain.fee_state.commit_base = base;
+    }
+
+    pub fn burned_total(&self) -> u64 {
+        self.chain.burned_total
+    }
+
+    pub fn balance_of(&self, who: &str) -> u64 {
+        *self.balances.get(who).unwrap_or(&0)
+    }
+
+    pub fn set_balance(&mut self, who: String, amount: u64) {
+        self.balances.insert(who, amount);
     }
 
     /// Build exactly one block from the current head and mempool.


### PR DESCRIPTION
## Summary
- make Node fields private to protect invariants
- add helper methods for state access (height, fee_state, balances, etc)
- update fees tests to use Node's new APIs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a484a372b8832e8de3d0cda079848a