### PR TITLE
Add chain block application tests

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -3,8 +3,8 @@
 use crate::codec::{header_bytes, header_signing_bytes};
 use crate::crypto::{addr_from_pubkey, addr_hex, hash_bytes_sha256, verify_ed25519};
 use crate::fees::{update_commit_base, update_exec_base, FeeState, FEE_PARAMS};
-use crate::stf::{process_block, BlockResult, BlockError};
-use crate::state::{Available, Balances, Commitments, Nonces, DECRYPTION_DELAY, REVEAL_WINDOW, ZERO_ADDRESS};
+use crate::stf::{process_block, BlockError};
+use crate::state::{Available, Balances, Commitments, Nonces, DECRYPTION_DELAY, REVEAL_WINDOW};
 use crate::types::{Block, Event, Hash, Receipt};
 use crate::verify::verify_block_roots;
 use std::collections::{HashMap, HashSet, BTreeMap};
@@ -187,4 +187,143 @@ impl Chain {
 
 mod tests {
     use super::*;
+    use ed25519_dalek::{SigningKey, Signer};
+    use crate::codec::{header_bytes, header_signing_bytes};
+    use crate::crypto::{hash_bytes_sha256, addr_from_pubkey, addr_hex};
+    use crate::state::{Balances, Nonces, Commitments, Available};
+    use crate::types::{Block, BlockHeader};
+
+    fn build_empty_block(
+        chain: &Chain,
+        signer: &SigningKey,
+        balances: &Balances,
+        nonces: &Nonces,
+        commitments: &Commitments,
+        available: &Available,
+    ) -> Block {
+        let mut block = Block {
+            header: BlockHeader {
+                parent_hash: chain.tip_hash,
+                height: chain.height + 1,
+                proposer_pubkey: signer.verifying_key().to_bytes(),
+                txs_root: [0u8; 32],
+                receipts_root: [0u8; 32],
+                gas_used: 0,
+                randomness: chain.tip_hash,
+                reveal_set_root: [0u8; 32],
+                il_root: [0u8; 32],
+                exec_base_fee: chain.fee_state.exec_base,
+                commit_base_fee: chain.fee_state.commit_base,
+                avail_base_fee: chain.fee_state.avail_base,
+                timestamp: 0,
+                signature: [0u8; 64],
+            },
+            transactions: Vec::new(),
+            reveals: Vec::new(),
+        };
+
+        let mut sim_balances = balances.clone();
+        let mut sim_nonces = nonces.clone();
+        let mut sim_commitments = commitments.clone();
+        let mut sim_available = available.clone();
+        let proposer_addr = addr_hex(&addr_from_pubkey(&block.header.proposer_pubkey));
+        let mut burned = 0u64;
+        let body = process_block(
+            &block,
+            &mut sim_balances,
+            &mut sim_nonces,
+            &mut sim_commitments,
+            &mut sim_available,
+            &chain.fee_state,
+            &proposer_addr,
+            &mut burned,
+        ).expect("process_block");
+
+        block.header.txs_root = body.txs_root;
+        block.header.receipts_root = body.receipts_root;
+        block.header.reveal_set_root = body.reveal_set_root;
+        block.header.il_root = body.il_root;
+        block.header.gas_used = body.gas_total;
+
+        let preimage = header_signing_bytes(&block.header);
+        let sig = signer.sign(&preimage).to_bytes();
+        block.header.signature = sig;
+
+        block
+    }
+
+    #[test]
+    fn apply_block1_advances_tip() {
+        let signer = SigningKey::from_bytes(&[1u8; 32]);
+        let mut chain = Chain::new();
+        let mut balances = Balances::default();
+        let mut nonces = Nonces::default();
+        let mut commitments = Commitments::default();
+        let mut available = Available::default();
+
+        let block = build_empty_block(&chain, &signer, &balances, &nonces, &commitments, &available);
+        chain
+            .apply_block(&block, &mut balances, &mut nonces, &mut commitments, &mut available)
+            .unwrap();
+
+        assert_eq!(chain.height, 1);
+        let expected_tip = hash_bytes_sha256(&header_bytes(&block.header));
+        assert_eq!(chain.tip_hash, expected_tip);
+    }
+
+    #[test]
+    fn applying_same_height_fails() {
+        let signer = SigningKey::from_bytes(&[2u8; 32]);
+        let mut chain = Chain::new();
+        let mut balances = Balances::default();
+        let mut nonces = Nonces::default();
+        let mut commitments = Commitments::default();
+        let mut available = Available::default();
+
+        let block1 = build_empty_block(&chain, &signer, &balances, &nonces, &commitments, &available);
+        chain
+            .apply_block(&block1, &mut balances, &mut nonces, &mut commitments, &mut available)
+            .unwrap();
+
+        let err = chain
+            .apply_block(&block1, &mut balances, &mut nonces, &mut commitments, &mut available)
+            .err()
+            .unwrap();
+        match err {
+            BlockError::BadHeight { expected, got } => {
+                assert_eq!(expected, 2);
+                assert_eq!(got, 1);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn applying_2_blocks_works_correctly() {
+        let signer = SigningKey::from_bytes(&[3u8; 32]);
+        let mut chain = Chain::new();
+        let mut balances = Balances::default();
+        let mut nonces = Nonces::default();
+        let mut commitments = Commitments::default();
+        let mut available = Available::default();
+
+        let block1 = build_empty_block(&chain, &signer, &balances, &nonces, &commitments, &available);
+        chain
+            .apply_block(&block1, &mut balances, &mut nonces, &mut commitments, &mut available)
+            .unwrap();
+        assert_eq!(chain.height, 1);
+
+        let block2 = build_empty_block(&chain, &signer, &balances, &nonces, &commitments, &available);
+        chain
+            .apply_block(&block2, &mut balances, &mut nonces, &mut commitments, &mut available)
+            .unwrap();
+
+        assert_eq!(chain.height, 2);
+        let expected_tip = hash_bytes_sha256(&header_bytes(&block2.header));
+        assert_eq!(chain.tip_hash, expected_tip);
+        assert_ne!(
+            chain.tip_hash,
+            hash_bytes_sha256(&header_bytes(&block1.header))
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- add helper to build minimal signed block for testing
- test tip advancement on first block application
- test duplicate height rejection and sequential block application

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a59a1b47a4832eab0ea8060dd7c474