### PR TITLE
Isolate process_block call count per test

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -318,7 +318,6 @@ use crate::mempool::{MempoolConfig, BlockSelectionLimits, BalanceView};
 use crate::fees::FeeState;
 use crate::types::{Transaction, Tx, CommitTx, RevealTx, Address};
 use crate::stf::PROCESS_BLOCK_CALLS;
-use std::sync::atomic::Ordering;
     use crate::codec::{tx_bytes, access_list_bytes, string_bytes};
     use crate::crypto::{commitment_hash, commit_signing_preimage, addr_from_pubkey, addr_hex};
 
@@ -448,9 +447,9 @@ use std::sync::atomic::Ordering;
         node.set_balance(sender.clone(), 1000);
         let (c, _r) = make_pair(&tx_sk, 0);
         mp.insert_commit(Tx::Commit(c), 0, 1, &bv, &FeeState::from_defaults()).unwrap();
-        PROCESS_BLOCK_CALLS.store(0, Ordering::SeqCst);
+        PROCESS_BLOCK_CALLS.with(|c| c.set(0));
         let limits = BlockSelectionLimits { max_avails: 10, max_reveals: 10, max_commits: 10 };
         node.produce_block(limits).unwrap();
-        assert_eq!(PROCESS_BLOCK_CALLS.load(Ordering::SeqCst), 1);
+        PROCESS_BLOCK_CALLS.with(|c| assert_eq!(c.get(), 1));
     }
 }

--- a/src/stf.rs
+++ b/src/stf.rs
@@ -17,10 +17,14 @@ use crate::types::{Block, Receipt, ExecOutcome, Hash, BlockHeader, Transaction, 
 use std::collections::HashSet;
 use std::fmt;
 #[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::cell::Cell;
+#[cfg(test)]
+use std::thread_local;
 
 #[cfg(test)]
-pub static PROCESS_BLOCK_CALLS: AtomicUsize = AtomicUsize::new(0);
+thread_local! {
+    pub static PROCESS_BLOCK_CALLS: Cell<usize> = Cell::new(0);
+}
 
 #[derive(Debug)]
 pub enum TxError {
@@ -508,7 +512,7 @@ pub fn process_block(
     burned_total: &mut u64,
 ) -> Result<BodyResult, BlockError> {
     #[cfg(test)]
-    PROCESS_BLOCK_CALLS.fetch_add(1, Ordering::SeqCst);
+    PROCESS_BLOCK_CALLS.with(|c| c.set(c.get() + 1));
     let mut receipts: Vec<Receipt> = Vec::new();
     let mut gas_total: u64 = 0;
     let mut reveals_included: u32 = 0;


### PR DESCRIPTION
## Summary
- avoid cross-test interference by using a thread-local counter for `process_block` invocation
- update node test to use the thread-local counter

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68a5f136926c832e98ec81146429493e