### PR TITLE
chore: drop deprecated node helpers

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -293,22 +293,6 @@ impl Node {
         Ok((built, res))
     }
 
-    #[deprecated(note = "use produce_block")]
-    pub fn produce_one_block(
-        &self,
-        limits: BlockSelectionLimits,
-    ) -> Result<BuiltBlock, ProduceError> {
-        let (built, _, _, _, _, _, _) = self.simulate_block(limits)?;
-        Ok(built)
-    }
-
-    #[deprecated(note = "use produce_block")]
-    pub fn produce_and_apply_once(
-        &mut self,
-        limits: BlockSelectionLimits,
-    ) -> Result<(BuiltBlock, ApplyResult), ProduceError> {
-        self.produce_block(limits)
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- remove deprecated block production helpers

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a5f3ef0fe0832ea5ed2b20b85904ae