### PR TITLE
Align test slots with proposer verification

### DIFF
--- a/tests/dev_loop.rs
+++ b/tests/dev_loop.rs
@@ -141,6 +141,7 @@ impl DevNode for RecordingNode {
     fn height(&self) -> u64 { self.inner.height() }
 
     fn produce_block(&mut self, limits: BlockSelectionLimits) -> Result<(BuiltBlock, ApplyResult), ProduceError> {
+        self.inner.align_clock_for_test();
         let (built, apply) = self.inner.produce_block(limits)?;
         let txc = built.block.transactions.len();
         let revc = built.block.reveals.len();


### PR DESCRIPTION
## Summary
- add helper to sync chain clock with current height for tests
- adjust unit tests to set genesis time and pass proposer/slot checks
- fix dev loop test by aligning clock before each produced block

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68a8b58f7b88832e9161eb8d37716c2d