### PR TITLE
Validate DKG public keys and test malformed inputs

### DIFF
--- a/src/mempool/encrypted.rs
+++ b/src/mempool/encrypted.rs
@@ -717,9 +717,11 @@ pub mod dkg {
             return Err(ThresholdError::InvalidPublicKey);
         }
 
-        for pk_bytes in validator_pks {
-            mpk::PublicKey::from_bytes(pk_bytes).map_err(|_| ThresholdError::InvalidPublicKey)?;
-        }
+        validator_pks.iter().try_for_each(|pk_bytes| {
+            mpk::PublicKey::from_bytes(pk_bytes)
+                .map(|_| ())
+                .map_err(|_| ThresholdError::InvalidPublicKey)
+        })?;
 
         let threshold_pk_bytes = validator_pks[0];
 

--- a/src/mempool/encrypted_tests.rs
+++ b/src/mempool/encrypted_tests.rs
@@ -362,3 +362,16 @@ fn test_large_transaction_data() {
     let decrypted = engine.decrypt(&ciphertext, &shares).unwrap();
     assert_eq!(decrypted, large_data);
 }
+
+#[test]
+fn test_malformed_public_key_rejected() {
+    let validators = setup_test_validators(1);
+    let mut validator_pks: Vec<[u8; 48]> =
+        validators.iter().map(|v| v.bls_public_key()).collect();
+
+    // Push malformed key bytes that are not a valid BLS12-381 point
+    validator_pks.push([0u8; 48]);
+
+    let result = dkg::generate_threshold_public_key(&validator_pks, 0, 1);
+    assert!(matches!(result, Err(ThresholdError::InvalidPublicKey)));
+}


### PR DESCRIPTION
## Summary
- Ensure DKG checks every validator public key by attempting BLS decoding and erroring on failure
- Add unit test verifying malformed public keys are rejected

## Testing
- `cargo +nightly test` *(fails: 54 passed, 27 failed)*

------
https://chatgpt.com/codex/tasks/task_b_68af0d4d0d00832e86b36946f698ac14